### PR TITLE
refactor files structure

### DIFF
--- a/framework.dart
+++ b/framework.dart
@@ -1,4 +1,7 @@
 library framework;
 
 export 'bindings.dart';
-export 'trees.dart';
+export 'geometry.dart';
+export 'render_object.dart';
+export 'widget.dart';
+export 'element.dart';

--- a/render_object.dart
+++ b/render_object.dart
@@ -128,38 +128,15 @@ abstract class RenderObject {
   }
 }
 
-class ViewConfiguration {
-  const ViewConfiguration({
-    this.size = Size.zero,
-    this.devicePixelRatio = 1.0,
-  });
-
-  final Size size;
-  final double devicePixelRatio;
-}
-
-class RenderView extends RenderObject {
-  RenderView({
-    RenderObject child,
-    ViewConfiguration configuration,
-  }) : _configuration = configuration {
-    this.child = child;
-  }
-
-  ViewConfiguration get configuration => _configuration;
-  ViewConfiguration _configuration;
-
+mixin RenderObjectWithChild on RenderObject {
   RenderObject get child => _child;
-  set child(RenderObject value) {
-    if (_child != null) dropChild(child);
+  void set child(RenderObject value) {
+    if (value == null) dropChild(child);
     _child = value;
     if (value != null) adoptChild(child);
   }
 
   RenderObject _child;
-
-  Size get size => _size;
-  Size _size = Size.zero;
 
   @override
   void attach(PipelineOwner owner) {
@@ -179,25 +156,12 @@ class RenderView extends RenderObject {
       visitor(child);
     }
   }
+}
 
-  void prepareInitialFrame() {
-    scheduleInitialLayout();
-  }
-
+mixin RootRenderObjectMixin on RenderObject {
   void scheduleInitialLayout() {
     _relayoutBoundary = this;
     owner._nodesNeedingLayout.add(this);
-  }
-
-  @override
-  void performLayout() {
-    _size = configuration.size;
-    child?.layout(BoxConstraints.tight(_size));
-  }
-
-  @override
-  void performResize() {
-    assert(false);
   }
 }
 

--- a/test.dart
+++ b/test.dart
@@ -1,8 +1,6 @@
 import 'dart:collection';
 
 import 'framework.dart';
-import 'geometry.dart';
-import 'render_object.dart';
 
 void main(List<String> args) {
   runApp(App());

--- a/widget.dart
+++ b/widget.dart
@@ -1,0 +1,66 @@
+import 'element.dart';
+import 'render_object.dart';
+
+abstract class Widget {
+  Element createElement();
+
+  static bool canUpdate(Widget oldWidget, Widget newWidget) {
+    return oldWidget.runtimeType == newWidget.runtimeType;
+  }
+}
+
+abstract class StatelessWidget extends Widget {
+  @override
+  Element createElement() => StatelessElement(this);
+
+  Widget build(Element context);
+}
+
+abstract class StatefulWidget extends Widget {
+  @override
+  Element createElement() => StatefulElement(this);
+
+  State<StatefulWidget> createState();
+}
+
+abstract class State<T extends StatefulWidget> {
+  T widget;
+  StatefulElement element;
+
+  void setState(void Function() fn) {
+    fn();
+    element.markNeedsBuild();
+  }
+
+  void initState() {}
+
+  void didUpdateWidget(T oldWidget) {}
+
+  Widget build(Element context);
+
+  void dispose() {}
+}
+
+abstract class RenderObjectWidget extends Widget {
+  @override
+  RenderObjectElement createElement();
+
+  RenderObject createRenderObject(Element context);
+
+  void updateRenderObject(Element context, covariant RenderObject renderObject);
+
+  void didUnmountRenderObject(covariant RenderObject renderObject);
+}
+
+abstract class LeafRenderObjectWidget extends RenderObjectWidget {
+  LeafRenderObjectElement createElement() => LeafRenderObjectElement(this);
+}
+
+abstract class SingleChildRenderObjectWidget extends RenderObjectWidget {
+  SingleChildRenderObjectWidget(this.child);
+
+  final Widget child;
+
+  @override
+  RenderObjectElement createElement() => SingleChildRenderObjectElement(this);
+}


### PR DESCRIPTION
also introduces RootRenderObjectMixin to move RenderView to bindings file since scheduleInitialLayout uses private fields